### PR TITLE
feat(models): add Claude 4.6 model support and bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - 2026-03-03
+
+### Added
+- Add Claude 4.6 models support (Opus 4.6, Sonnet 4.6)
+- Set claude-opus-4.6 as default model
+
 ## [2.0.4] - 2026-01-26
 
 ### Fixed

--- a/ai-agent-server/src/main/kotlin/com/asakii/server/HttpApiServer.kt
+++ b/ai-agent-server/src/main/kotlin/com/asakii/server/HttpApiServer.kt
@@ -512,6 +512,16 @@ class HttpApiServer(
                                     // 内置模型列表
                                     val builtInClaudeModels = listOf(
                                         mapOf(
+                                            "displayName" to JsonPrimitive("Opus 4.6"),
+                                            "modelId" to JsonPrimitive("claude-opus-4-6"),
+                                            "isBuiltIn" to JsonPrimitive(true)
+                                        ),
+                                        mapOf(
+                                            "displayName" to JsonPrimitive("Sonnet 4.6"),
+                                            "modelId" to JsonPrimitive("claude-sonnet-4-6"),
+                                            "isBuiltIn" to JsonPrimitive(true)
+                                        ),
+                                        mapOf(
                                             "displayName" to JsonPrimitive("Opus 4.5"),
                                             "modelId" to JsonPrimitive("claude-opus-4-5-20251101"),
                                             "isBuiltIn" to JsonPrimitive(true)

--- a/ai-agent-server/src/main/kotlin/com/asakii/server/rpc/AiAgentRpcServiceImpl.kt
+++ b/ai-agent-server/src/main/kotlin/com/asakii/server/rpc/AiAgentRpcServiceImpl.kt
@@ -1923,6 +1923,16 @@ class AiAgentRpcServiceImpl(
         // 内置模型
         val builtInModels = listOf(
             RpcModelInfo(
+                displayName = "Opus 4.6",
+                modelId = "claude-opus-4-6",
+                isBuiltIn = true
+            ),
+            RpcModelInfo(
+                displayName = "Sonnet 4.6",
+                modelId = "claude-sonnet-4-6",
+                isBuiltIn = true
+            ),
+            RpcModelInfo(
                 displayName = "Opus 4.5",
                 modelId = "claude-opus-4-5-20251101",
                 isBuiltIn = true

--- a/frontend/src/constants/models.ts
+++ b/frontend/src/constants/models.ts
@@ -44,6 +44,20 @@ export interface ModelCapability {
  * 内置模型能力映射（以 modelId 作为唯一键）
  */
 const MODEL_CAPABILITIES: Record<string, ModelCapability> = {
+  'claude-opus-4-6': {
+    modelId: 'claude-opus-4-6',
+    displayName: 'Opus 4.6',
+    thinkingMode: 'optional',
+    defaultThinkingEnabled: true,
+    description: 'Most powerful model for complex tasks',
+  },
+  'claude-sonnet-4-6': {
+    modelId: 'claude-sonnet-4-6',
+    displayName: 'Sonnet 4.6',
+    thinkingMode: 'optional',
+    defaultThinkingEnabled: true,
+    description: 'Balanced performance and cost',
+  },
   'claude-opus-4-5-20251101': {
     modelId: 'claude-opus-4-5-20251101',
     displayName: 'Opus 4.5',
@@ -74,6 +88,8 @@ const MODEL_CAPABILITIES: Record<string, ModelCapability> = {
  * 通过 updateAllModels() 从后端刷新
  */
 const _allModels = ref<ModelInfo[]>([
+  { modelId: 'claude-opus-4-6', displayName: 'Opus 4.6', isBuiltIn: true },
+  { modelId: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', isBuiltIn: true },
   { modelId: 'claude-opus-4-5-20251101', displayName: 'Opus 4.5', isBuiltIn: true },
   { modelId: 'claude-sonnet-4-5-20250929', displayName: 'Sonnet 4.5', isBuiltIn: true },
   { modelId: 'claude-haiku-4-5-20251001', displayName: 'Haiku 4.5', isBuiltIn: true },
@@ -82,7 +98,7 @@ const _allModels = ref<ModelInfo[]>([
 /**
  * 当前默认模型 ID
  */
-const _defaultModelId = ref<string>('claude-opus-4-5-20251101')
+const _defaultModelId = ref<string>('claude-opus-4-6')
 
 /**
  * 模型列表变化回调列表

--- a/frontend/src/services/backendCapabilities.ts
+++ b/frontend/src/services/backendCapabilities.ts
@@ -30,11 +30,25 @@ import {
  */
 export const CLAUDE_MODELS: BackendModelInfo[] = [
   {
+    modelId: 'claude-opus-4-6',
+    displayName: 'Claude Opus 4.6',
+    description: 'Most capable model for complex tasks',
+    supportsThinking: true,
+    isDefault: true,
+  },
+  {
+    modelId: 'claude-sonnet-4-6',
+    displayName: 'Claude Sonnet 4.6',
+    description: 'Balanced performance and cost',
+    supportsThinking: true,
+    isDefault: false,
+  },
+  {
     modelId: 'claude-opus-4-5-20251101',
     displayName: 'Claude Opus 4.5',
     description: 'Most capable model for complex tasks',
     supportsThinking: true,
-    isDefault: true,
+    isDefault: false,
   },
   {
     modelId: 'claude-sonnet-4-5-20250929',

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -46,7 +46,7 @@ const DEFAULT_SETTINGS: Settings = {
   },
 
   // Claude 设置（向后兼容，实际值从后端获取）
-  claudeModel: 'claude-opus-4-5-20251101',
+  claudeModel: 'claude-opus-4-6',
   claudeThinkingEnabled: null,   // 从后端获取
   claudeThinkingTokens: null,    // 从后端获取
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ platformType = IU
 platformVersion = 2025.3.1.1
 
 # Plugin Version
-pluginVersion = 2.0.4
+pluginVersion = 2.1.0
 
 # Plugin Signing
 # signPlugin.keystore =

--- a/jetbrains-plugin/src/main/kotlin/com/asakii/settings/AgentSettingsService.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/asakii/settings/AgentSettingsService.kt
@@ -122,7 +122,7 @@ class AgentSettingsService : PersistentStateComponent<AgentSettingsService.State
         var codexCustomModels: String = "[]",
 
         // 默认模型（使用实际 modelId 存储）
-        var defaultModel: String = "claude-opus-4-5-20251101",
+        var defaultModel: String = "claude-opus-4-6",
 
         // 默认思考等级 ID（如 "off", "think", "ultra", "custom_xxx"）
         var defaultThinkingLevelId: String = "ultra",
@@ -150,6 +150,16 @@ class AgentSettingsService : PersistentStateComponent<AgentSettingsService.State
     private var state = State()
 
     private val builtInClaudeModels = listOf(
+        ModelInfo(
+            modelId = "claude-opus-4-6",
+            displayName = "Opus 4.6",
+            isBuiltIn = true
+        ),
+        ModelInfo(
+            modelId = "claude-sonnet-4-6",
+            displayName = "Sonnet 4.6",
+            isBuiltIn = true
+        ),
         ModelInfo(
             modelId = "claude-opus-4-5-20251101",
             displayName = "Opus 4.5",

--- a/jetbrains-plugin/src/main/kotlin/com/asakii/settings/ClaudeCodeConfigurable.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/asakii/settings/ClaudeCodeConfigurable.kt
@@ -216,7 +216,7 @@ class ClaudeCodeConfigurable : SearchableConfigurable {
                 }
                 row { comment("Path to Node.js executable. Leave empty to auto-detect from system PATH.") }
                 row("Default model:") { cell(defaultModelCombo!!).columns(COLUMNS_MEDIUM) }
-                row { comment("Opus 4.5 = Most capable | Sonnet 4.5 = Balanced | Haiku 4.5 = Fastest") }
+                row { comment("Opus 4.6 = Most capable | Sonnet 4.6 = Balanced | Haiku 4.5 = Fastest") }
             }
 
             collapsibleGroup("Custom Models") {
@@ -644,7 +644,7 @@ class ClaudeCodeConfigurable : SearchableConfigurable {
 
         val selectedModel = defaultModelCombo?.selectedItem as? ModelInfo
         settings.defaultModel = selectedModel?.modelId ?: settings.getAllAvailableModels().firstOrNull { it.isBuiltIn }?.modelId
-            ?: "claude-opus-4-5-20251101"
+            ?: "claude-opus-4-6"
 
         val existing = settings.getCustomModels().associateBy { it.modelId }
         val custom = getCustomModelsFromTable().map { m ->


### PR DESCRIPTION
Add support for Claude Opus 4.6 and Claude Sonnet 4.6 models across all modules (backend, frontend, plugin settings). Set claude-opus-4-6 as the new default model. Update version to 2.1.0 in gradle.properties and CHANGELOG.md.

https://github.com/Dutch77/claude-code-plus/releases/download/v2.1.0/claude-code-plus-jetbrains-plugin-2.1.0.253.zip